### PR TITLE
Remove News and Pro Knowledge sections from frontend

### DIFF
--- a/frontend/pages/1_Dashboard.py
+++ b/frontend/pages/1_Dashboard.py
@@ -37,7 +37,7 @@ if st.session_state.analysis_result:
         st.error(f"Error: {data['error']}")
     else:
         # --- Tabs Layout ---
-        tab_overview, tab_charts, tab_financials, tab_news = st.tabs(["Overview", "Technical Charts", "Financials", "News"])
+        tab_overview, tab_charts, tab_financials = st.tabs(["Overview", "Technical Charts", "Financials"])
 
         with tab_overview:
             # 1. Top Section: Price & Trend
@@ -118,13 +118,6 @@ if st.session_state.analysis_result:
                 st.dataframe(df_fin[final_cols].style.highlight_max(axis=0))
             else:
                 st.info("No financial details.")
-
-        with tab_news:
-             st.subheader("📰 Recent News")
-             news = data.get('news', [])
-             for n in news:
-                 with st.expander(f"{n.get('title')} - {n.get('publisher')}"):
-                     st.markdown(f"[Read Article]({n.get('link')})")
 
         # 6. Contextual Chat (Always visible at bottom)
         st.divider()

--- a/frontend/pages/4_Options_Analysis.py
+++ b/frontend/pages/4_Options_Analysis.py
@@ -202,10 +202,9 @@ def calibrate_sabr(strikes, market_ivs, f, t):
 # Layout
 # ---------------------------------------------------------------------------
 
-tab_mispricing, tab_surface, tab_knowledge = st.tabs([
+tab_mispricing, tab_surface = st.tabs([
     "🚀 Mispricing (SABR)",
     "📊 Volatility Surface",
-    "🧠 Pro Knowledge",
 ])
 
 # ---------------------------------------------------------------------------
@@ -367,39 +366,4 @@ with tab_surface:
     )
     st.plotly_chart(fig_surf, use_container_width=True)
 
-# ---------------------------------------------------------------------------
-# TAB 3 — Pro Knowledge
-# ---------------------------------------------------------------------------
-with tab_knowledge:
-    st.markdown("""
-    # The RIGHT way to trade Options in India 🇮🇳
 
-    ### ❌ Why 90% of Retail Sellers Lose
-    1. **Ignoring the Smile**: They sell OTM puts assuming "BS fair value" is correct.
-       In reality, **SABR Skew** shows OTM puts trade at a huge premium (Crash Fear).
-       If you sell cheap, one spike wipes you out.
-    2. **No Gamma Control**: Selling weeklies looks profitable (Theta decay),
-       but **Gamma Risk** explodes in the last 2 days.
-    3. **Static Greeks**: They use Greeks from the start of the day.
-       Market Makers update Greeks **every millisecond** using stochastic models.
-
-    ### 🔥 The Pro Stack
-    1. **SABR**: Captures the Skew/Smile (implemented in Tab 1).
-    2. **Heston Model**: Adds stochastic volatility dynamics (volatility of volatility).
-    3. **Dupire**: Local volatility model for "True" No-Arbitrage.
-    """)
-
-    st.divider()
-
-    st.subheader("💻 Heston Pricing Code (Python)")
-    st.code("""
-import numpy as np
-
-def heston_price(S, K, T, r, kappa, theta, sigma, rho, v0):
-    # Integration of Characteristic Function (Semi-closed form)
-    # Captures that volatility itself is random/stochastic:
-    # dS = mu*S*dt + sqrt(v)*S*dW1
-    # dv = kappa*(theta - v)*dt + sigma*sqrt(v)*dW2
-    pass
-    # Use 'quantlib' or 'scipy.integrate' for full implementation
-    """, language="python")


### PR DESCRIPTION
## Problem
Two sections exist in the frontend that are not needed and should be fully removed:
1. "Recent News" tab in the Market Trend Predictor (`1_Dashboard.py`)
2. "Pro Knowledge" tab in the Options Analysis page (`4_Options_Analysis.py`)

## Tasks
- [x] Remove the News tab and its rendering logic from `frontend/pages/1_Dashboard.py`
- [x] Remove any news-fetching calls tied to the News tab display
- [x] Remove the "Pro Knowledge" tab and all its content from `frontend/pages/4_Options_Analysis.py`
- [x] Ensure all remaining tabs and functionality are unaffected