### PR TITLE
Fix Deep Report Generation (quant-reporter Crash with yfinance >= 0.2.40)

### DIFF
--- a/frontend/pages/3_Portfolio.py
+++ b/frontend/pages/3_Portfolio.py
@@ -8,6 +8,44 @@ import streamlit.components.v1 as components
 # Import quant_reporter
 try:
     import quant_reporter as qr
+    import yfinance as yf
+    import pandas as pd
+    import numpy as np
+
+    # --- MONKEY PATCH FOR quant_reporter TO HANDLE yfinance>=0.2.40 SERIES OBJECTS ---
+    if hasattr(qr, 'opt_core'):
+        # 1. Patch get_risk_free_rate
+        def patched_get_risk_free_rate():
+            try:
+                tbill = yf.download("^IRX", period="5d")
+                if tbill is None or tbill.empty:
+                    raise Exception("^IRX download failed")
+                # Correctly handle potential Series object return
+                latest_rate = float(np.ravel(tbill['Close'].iloc[-1])[0]) / 100 
+                if not 0 <= latest_rate <= 0.2:
+                     raise Exception("Rate unrealistic.")
+                return latest_rate
+            except Exception as e:
+                return 0.06
+        qr.opt_core.get_risk_free_rate = patched_get_risk_free_rate
+
+        # 2. Patch calculate_rolling_returns
+        def patched_calculate_rolling_returns(cumulative_df):
+            periods = {'1-Year': 252, '3-Year': 252*3, '5-Year': 252*5}
+            rolling_returns = {}
+            for name, days in periods.items():
+                if len(cumulative_df) > days:
+                    years = days / 252
+                    # Extract scalar value instead of ambiguous Series
+                    end_val = float(np.ravel(cumulative_df.iloc[-1])[0])
+                    start_val = float(np.ravel(cumulative_df.iloc[-days-1])[0])
+                    rolling_returns[name] = [(end_val / start_val)**(1/years) - 1]
+                else:
+                    rolling_returns[name] = [np.nan]
+            return pd.DataFrame.from_dict(rolling_returns, orient='index').map(lambda x: f"{x:.2%}" if not pd.isna(x) else "N/A")
+        qr.opt_core.calculate_rolling_returns = patched_calculate_rolling_returns
+    # ---------------------------------------------------------------------------------
+
     QUANT_REPORTER_AVAILABLE = True
 except ImportError:
     QUANT_REPORTER_AVAILABLE = False


### PR DESCRIPTION
### Problem
The "Deep Report" generation tab was throwing an ambiguous "Truth value of a Series" error when `quant-reporter` ran its background risk-free rate calculations.
This crash was introduced precisely because we recently bumped `yfinance` to `>=0.2.40` in [requirements.txt](cci:7://file:///c:/QuantVis/backend/requirements.txt:0:0-0:0). In these newer yfinance versions, queries frequently return a pandas `Series` instead of a plain `float`. The upstream `quant-reporter` package was not fully compatible with this `Series` return type.

### Proposed Change
Instead of downgrading `yfinance` (which would break our news parser) or forcing everyone to manually edit files in their `venv`, I have injected a lightweight monkey patch directly into [frontend/pages/3_Portfolio.py](cci:7://file:///c:/QuantVis/frontend/pages/3_Portfolio.py:0:0-0:0). 
Whenever `quant-reporter` is loaded in the frontend, its sub-module `opt_core` functions ([get_risk_free_rate](cci:1://file:///C:/QuantVis/backend/venv/Lib/site-packages/quant_reporter/opt_core.py:152:0-172:19) and [calculate_rolling_returns](cci:1://file:///C:/QuantVis/backend/venv/Lib/site-packages/quant_reporter/opt_core.py:174:0-188:121)) are securely patched on-the-fly to handle pandas Series unpacking via `np.ravel()`. 

### Advantages
- The Deep Report now generates completely successfully without failing on multi-index or Series data.
- Everyone who pulls this branch gets the fix immediately; no manual `site-packages` tweaks are required for any team member!
- `yfinance` remains safely above `>=0.2.40` for our other micro-services.
